### PR TITLE
Optionally require NumPy in template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,7 @@
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "use_pypi_deployment_with_travis": "y",
+  "require_numpy": "n",
   "create_author_file": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]
 }

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -45,3 +45,6 @@ The following package configuration options set up different features for your p
 
 use_pypi_deployment_with_travis
     Whether to use PyPI deployment with Travis.
+
+require_numpy
+    Whether to make NumPy a requirement of the package build and install.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ pytest-cookies==0.2.0
 watchdog==0.8.3
 alabaster==0.7.8
 Cython==0.25.2
+numpy==1.11.3

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -111,6 +111,13 @@ def test_bake_with_apostrophe_and_run_tests(cookies):
         run_inside_dir('python setup.py test', str(result.project)) == 0
 
 
+def test_bake_with_numpy_and_run_tests(cookies):
+    """Ensure that requiring NumPy does not break setup.py"""
+    with bake_in_temp_dir(cookies, extra_context={'require_numpy': 'y'}) as result:
+        assert result.project.isdir()
+        run_inside_dir('python setup.py test', str(result.project)) == 0
+
+
 def test_bake_and_run_travis_pypi_setup(cookies):
     # given:
     with bake_in_temp_dir(cookies) as result:

--- a/{{cookiecutter.project_name}}/environment_ci.yml
+++ b/{{cookiecutter.project_name}}/environment_ci.yml
@@ -9,3 +9,6 @@ dependencies:
   - coverage==4.4.2
   - pytest==3.0.5
   - cython==0.25.2
+  {% if cookiecutter.require_numpy == 'y' -%}
+  - numpy==1.11.3
+  {%- endif %}

--- a/{{cookiecutter.project_name}}/environment_doc.yml
+++ b/{{cookiecutter.project_name}}/environment_doc.yml
@@ -8,3 +8,6 @@ dependencies:
   - wheel==0.29.0
   - Sphinx==1.5.1
   - cython==0.25.2
+  {% if cookiecutter.require_numpy == 'y' -%}
+  - numpy==1.11.3
+  {%- endif %}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -3,4 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython",
+    {% if cookiecutter.require_numpy == 'y' -%}
+    "numpy",
+    {%- endif %}
 ]

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -37,9 +37,15 @@ with open("HISTORY.rst") as history_file:
 
 setup_requirements = [
     "cython>=0.25.2",
+    {% if cookiecutter.require_numpy == 'y' -%}
+    "numpy>=1.11.3",
+    {%- endif %}
 ]
 
 install_requirements = [
+    {% if cookiecutter.require_numpy == 'y' -%}
+    "numpy>=1.11.3",
+    {%- endif %}
     # TODO: put package install requirements here
 ]
 

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -7,11 +7,25 @@ import sys
 
 import setuptools
 from setuptools import setup, Extension
+{% if cookiecutter.require_numpy == 'y' -%}
+from setuptools.command.build_ext import build_ext as BuildExtCommand
+{%- endif %}
 from setuptools.command.test import test as TestCommand
 
 from distutils.sysconfig import get_config_var, get_python_inc
 
 import versioneer
+
+
+{% if cookiecutter.require_numpy == 'y' -%}
+class NumPyBuildExt(BuildExtCommand):
+    def finalize_options(self):
+        BuildExtCommand.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+{%- endif %}
 
 
 class PyTest(TestCommand):
@@ -55,6 +69,9 @@ test_requirements = [
 
 cmdclasses = dict()
 cmdclasses.update(versioneer.get_cmdclass())
+{% if cookiecutter.require_numpy == 'y' -%}
+cmdclasses["build_ext"] = NumPyBuildExt
+{%- endif %}
 cmdclasses["test"] = PyTest
 
 {%- set license_classifiers = {

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_import}}.pxd
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_import}}.pxd
@@ -1,0 +1,3 @@
+{% if cookiecutter.require_numpy == 'y' -%}
+cimport numpy
+{%- endif %}

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_import}}.pyx
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_import}}.pyx
@@ -1,3 +1,8 @@
+{% if cookiecutter.require_numpy == 'y' -%}
+cimport numpy
+import numpy
+
+{%- endif %}
 cimport {{cookiecutter.project_import}}
 
 include "version.pxi"


### PR DESCRIPTION
Provide the option to require NumPy in the template during build and install. Provides a neat trick to workaround the `setup_requires` chicken-or-the-egg problem.