### PR TITLE
Template tweaks for AppVeyor

### DIFF
--- a/{{cookiecutter.project_name}}/.appveyor.yml
+++ b/{{cookiecutter.project_name}}/.appveyor.yml
@@ -10,14 +10,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 3.5
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 3.5
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 3.6
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -16,6 +16,10 @@
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
         :alt: Travis CI
 
+.. image:: https://ci.appveyor.com/api/projects/status/github/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}?svg=true&branch=master
+        :target: https://ci.appveyor.com/project/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}
+        :alt: AppVeyor
+
 .. image:: https://readthedocs.org/projects/{{ cookiecutter.project_name | replace("_", "-") }}/badge/?version=latest
         :target: https://{{ cookiecutter.project_name | replace("_", "-") }}.readthedocs.io/en/latest/?badge=latest
         :alt: Read the Docs


### PR DESCRIPTION
Add an AppVeyor badge to the template's README. Also drop Python 3.5 from the template's AppVeyor matrix.